### PR TITLE
Extract dependencies to version catalog

### DIFF
--- a/coffee-machine-adapters/build.gradle.kts
+++ b/coffee-machine-adapters/build.gradle.kts
@@ -3,11 +3,11 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
-    kotlin("jvm") version "2.2.10"
-    kotlin("plugin.spring") version "2.2.10"
-    id("org.springframework.boot") version "3.5.5"
-    id("org.jetbrains.kotlin.plugin.jpa") version "2.2.10"
-    id("io.spring.dependency-management") version "1.1.7"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.springboot)
+    alias(libs.plugins.spring.dependency.management)
 }
 
 repositories {
@@ -15,29 +15,17 @@ repositories {
 }
 
 dependencies {
+    // Project
     implementation(project(":coffee-machine-domain"))
     implementation(project(":coffee-machine-application"))
 
-    // Spring Boot
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation(libs.bundles.kotlin.all)
+    implementation(libs.bundles.springboot.all)
+    implementation(libs.bundles.persistence.all)
+    implementation(libs.kotlin.logging)
 
-    // Flyway support
-    implementation("org.flywaydb:flyway-core:11.11.1")
-    implementation("com.h2database:h2:2.3.232")
-
-    implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
-
-    // Kotlin
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.2")
-    implementation(kotlin("reflect"))
-
-
-    // H2 in-memory database
-    runtimeOnly("com.h2database:h2")
-
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-
+    testImplementation(libs.bundles.unittest.all)
+    testImplementation(libs.bundles.test.integration.all)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,72 @@
 [versions]
 
+flyway = "11.11.1"
+h2 = "2.3.232"
+jackson = "2.19.2"
 junit = "5.13.4"
 jvmTarget = "21"
 kotest = "6.0.0"
 kotlin = "2.2.10"
+kotlinLogging = "7.0.3"
 spotless = "7.2.1"
+springDependencyManagement = "1.1.7"
+springboot = "3.5.5"
 
 [libraries]
 
+# Kotlin
+kotlin-jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" , version.ref = "jackson" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+
+# Spring
+springboot-starter-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springboot" }
+springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
+springboot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springboot" }
+
+# Persistence
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+h2-database = { module = "com.h2database:h2", version.ref = "h2" }
+
+# Logging
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlinLogging" }
+
+# Tests
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
 
 [plugins]
 
+kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
+springboot = { id = "org.springframework.boot", version.ref = "springboot" }
 
 [bundles]
 
+kotlin-all = [
+    "kotlin-jackson",
+    "kotlin-reflect",
+    "kotlin-stdlib",
+]
+
+persistence-all = [
+    "flyway-core",
+    "h2-database",
+]
+
+springboot-all = [
+    "springboot-starter-jpa",
+    "springboot-starter-web",
+]
+
 unittest-all = [
-  "junit-jupiter-params",
-  "kotest-assertions-core"
+    "junit-jupiter-params",
+    "kotest-assertions-core"
+]
+
+test-integration-all = [
+    "springboot-starter-test",
 ]


### PR DESCRIPTION


# Purpose

This commit moves the dependencies that have been specified in the adapters hexagon build script into the shared version catalog for better dependency management and version control across the project

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed
