### PR TITLE
Move MachineStatus to the domain

### DIFF
--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/CoffeeMachinePowerPort.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/CoffeeMachinePowerPort.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.coffeemachine.application.ports.input
 
-import com.yonatankarp.coffeemachine.application.usecase.model.MachineStatus
+import com.yonatankarp.coffeemachine.domain.machine.MachineStatus
 
 fun interface CoffeeMachinePowerPort {
     operator fun invoke(on: Boolean): MachineStatus

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/CoffeeMachineRefillPort.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/CoffeeMachineRefillPort.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.coffeemachine.application.ports.input
 
-import com.yonatankarp.coffeemachine.application.usecase.model.MachineStatus
+import com.yonatankarp.coffeemachine.domain.machine.MachineStatus
 import com.yonatankarp.coffeemachine.domain.machine.RefillType
 
 fun interface CoffeeMachineRefillPort {

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/CoffeeMachineStatusPort.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/CoffeeMachineStatusPort.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.coffeemachine.application.ports.input
 
-import com.yonatankarp.coffeemachine.application.usecase.model.MachineStatus
+import com.yonatankarp.coffeemachine.domain.machine.MachineStatus
 
 fun interface CoffeeMachineStatusPort {
     operator fun invoke(): MachineStatus

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachinePowerUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachinePowerUseCase.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
 import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachinePowerPort
-import com.yonatankarp.coffeemachine.application.usecase.model.MachineStatus
+import com.yonatankarp.coffeemachine.domain.machine.MachineStatus
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 
 class CoffeeMachinePowerUseCase(

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineRefillUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineRefillUseCase.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
 import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachineRefillPort
-import com.yonatankarp.coffeemachine.application.usecase.model.MachineStatus
+import com.yonatankarp.coffeemachine.domain.machine.MachineStatus
 import com.yonatankarp.coffeemachine.domain.machine.RefillType
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineStatusUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineStatusUseCase.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
 import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachineStatusPort
-import com.yonatankarp.coffeemachine.application.usecase.model.MachineStatus
+import com.yonatankarp.coffeemachine.domain.machine.MachineStatus
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 
 class CoffeeMachineStatusUseCase(

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/BeansStatus.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/BeansStatus.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.coffeemachine.application.usecase.model
+package com.yonatankarp.coffeemachine.domain.machine
 
 import com.yonatankarp.coffeemachine.domain.shared.unit.Grams
 

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/MachineStatus.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/MachineStatus.kt
@@ -1,6 +1,4 @@
-package com.yonatankarp.coffeemachine.application.usecase.model
-
-import com.yonatankarp.coffeemachine.domain.machine.CoffeeMachine
+package com.yonatankarp.coffeemachine.domain.machine
 
 data class MachineStatus(
     val model: CoffeeMachine.Model,

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/WasteStatus.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/WasteStatus.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.coffeemachine.application.usecase.model
+package com.yonatankarp.coffeemachine.domain.machine
 
 data class WasteStatus(
     val currentPucks: Int,

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/WaterStatus.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/WaterStatus.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.coffeemachine.application.usecase.model
+package com.yonatankarp.coffeemachine.domain.machine
 
 import com.yonatankarp.coffeemachine.domain.shared.unit.Milliliters
 

--- a/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/BeanStatusFixture.kt
+++ b/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/BeanStatusFixture.kt
@@ -1,0 +1,27 @@
+package com.yonatankarp.coffeemachine.domain.machine
+
+import com.yonatankarp.coffeemachine.domain.shared.unit.Grams
+import com.yonatankarp.coffeemachine.domain.shared.unit.GramsFixture
+
+object BeanStatusFixture {
+    val empty: BeansStatus
+        get() =
+            BeansStatus(
+                current = Grams.ZERO,
+                capacity = GramsFixture.fiveHundred,
+            )
+
+    val used: BeansStatus
+        get() =
+            BeansStatus(
+                current = GramsFixture.threeHundred,
+                capacity = GramsFixture.fiveHundred,
+            )
+
+    val full: BeansStatus
+        get() =
+            BeansStatus(
+                current = GramsFixture.fiveHundred,
+                capacity = GramsFixture.fiveHundred,
+            )
+}

--- a/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/MachineStatusFixture.kt
+++ b/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/MachineStatusFixture.kt
@@ -1,0 +1,43 @@
+package com.yonatankarp.coffeemachine.domain.machine
+
+object MachineStatusFixture {
+    val poweredOff: MachineStatus
+        get() =
+            machineStatus(
+                poweredOn = false,
+                water = WaterStatusFixture.empty,
+                beans = BeanStatusFixture.empty,
+                waste = WasteStatusFixture.empty,
+            )
+
+    val poweredOn: MachineStatus
+        get() =
+            machineStatus(
+                poweredOn = true,
+                water = WaterStatusFixture.full,
+                beans = BeanStatusFixture.full,
+                waste = WasteStatusFixture.empty,
+            )
+
+    val used: MachineStatus
+        get() =
+            machineStatus(
+                poweredOn = true,
+                water = WaterStatusFixture.used,
+                beans = BeanStatusFixture.used,
+                waste = WasteStatusFixture.used,
+            )
+
+    private fun machineStatus(
+        poweredOn: Boolean,
+        water: WaterStatus,
+        beans: BeansStatus,
+        waste: WasteStatus,
+    ) = MachineStatus(
+        model = CoffeeMachine.Model("KotlinBarista 3000"),
+        poweredOn = poweredOn,
+        water = water,
+        beans = beans,
+        waste = waste,
+    )
+}

--- a/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/WasteStatusFixture.kt
+++ b/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/WasteStatusFixture.kt
@@ -1,0 +1,24 @@
+package com.yonatankarp.coffeemachine.domain.machine
+
+object WasteStatusFixture {
+    val empty: WasteStatus
+        get() =
+            WasteStatus(
+                currentPucks = 0,
+                capacityPucks = 10,
+            )
+
+    val used: WasteStatus
+        get() =
+            WasteStatus(
+                currentPucks = 3,
+                capacityPucks = 10,
+            )
+
+    val full: WasteStatus
+        get() =
+            WasteStatus(
+                currentPucks = 10,
+                capacityPucks = 10,
+            )
+}

--- a/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/WaterStatusFixture.kt
+++ b/coffee-machine-domain/src/testFixtures/kotlin/com/yonatankarp/coffeemachine/domain/machine/WaterStatusFixture.kt
@@ -1,0 +1,27 @@
+package com.yonatankarp.coffeemachine.domain.machine
+
+import com.yonatankarp.coffeemachine.domain.shared.unit.Milliliters
+import com.yonatankarp.coffeemachine.domain.shared.unit.MillilitersFixture
+
+object WaterStatusFixture {
+    val empty: WaterStatus
+        get() =
+            WaterStatus(
+                current = Milliliters.ZERO,
+                capacity = MillilitersFixture.oneThousand,
+            )
+
+    val used: WaterStatus
+        get() =
+            WaterStatus(
+                current = MillilitersFixture.fiveHundred,
+                capacity = MillilitersFixture.oneThousand,
+            )
+
+    val full: WaterStatus
+        get() =
+            WaterStatus(
+                current = MillilitersFixture.oneThousand,
+                capacity = MillilitersFixture.oneThousand,
+            )
+}


### PR DESCRIPTION

# Purpose

This commit moves the machine status object and its internal value objects to the domain and introducing a fixture for them to be used by the other hexagons in the project.

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed
