### PR TITLE
Add JaCoCo for code coverage reporting and include Code of Conduct and Contributing guidelines

### DIFF
--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -1,0 +1,122 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+*   Demonstrating empathy and kindness toward other people
+*   Being respectful of differing opinions, viewpoints, and experiences
+*   Giving and gracefully accepting constructive feedback
+*   Accepting responsibility and apologizing to those affected by our mistakes,
+    and learning from the experience
+*   Focusing on what is best not just for us as individuals, but for the
+    overall community
+
+Examples of unacceptable behavior include:
+
+*   The use of sexualized language or imagery, and sexual attention or
+    advances of any kind
+*   Trolling, insulting or derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or email
+    address, without their explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[yonatankarp@gmail.com](mailto:yonatankarp@gmail.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interaction in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,35 @@
+# Contributing to Coffee Machine Simulator
+
+First off, thank you for considering contributing to Coffee Machine Simulator! It's people like you that make open source such a great community.
+
+## Where do I start?
+
+If you're looking for a place to start, check out the open issues on GitHub. You can also a feature or suggest an improvement by opening a new issue.
+
+## Setting up your development environment
+
+To get started, you'll need to have the following installed:
+
+*   Java 21
+*   Gradle 8.x
+
+Once you have those installed, you can clone the repository and build the project:
+
+```bash
+git clone https://github.com/yonatankarp/coffee-machine-simulator.git
+cd coffee-machine-simulator
+./gradlew build
+```
+
+## Submitting a pull request
+
+When you're ready to submit a pull request, please make sure to do the following:
+
+*   Run the tests to make sure that everything is still working as expected.
+*   Format your code using Spotless.
+*   Update the documentation if you've made any changes to the API or the CLI.
+*   Add a descriptive title and a clear summary of your changes.
+
+## Code of conduct
+
+This project and everyone participating in it is governed by the [Contributor Covenant Code of Conduct](code_of_conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [yonatankarp@gmail.com](mailto:yonatankarp@gmail.com).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 plugins {
     alias(libs.plugins.kotlin.jvm) apply true
     alias(libs.plugins.spotless) apply true
+    jacoco
 }
 
 repositories {
@@ -30,5 +31,18 @@ subprojects {
 
     tasks.withType<KotlinCompilationTask<*>>().configureEach {
         dependsOn("spotlessCheck")
+    }
+
+    tasks.withType<Test> {
+        finalizedBy(tasks.withType<JacocoReport>()) // report is always generated after tests run
+    }
+
+    tasks.withType<JacocoReport> {
+        dependsOn(tasks.withType<Test>()) // tests are required to run before generating the report
+        reports {
+            xml.required.set(true)
+            csv.required.set(false)
+            html.required.set(true)
+        }
     }
 }


### PR DESCRIPTION
👆 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Code of Conduct outlining community standards and enforcement guidelines.
  - Added a Contributing Guide with setup steps, workflow tips, and a pull request checklist.

- Tests
  - Enabled code coverage reporting with JaCoCo, generating XML and HTML reports after test runs.

- Chores
  - Integrated coverage tasks into the build lifecycle to automatically produce reports post-testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->