### PR TITLE
Change port names to domain concepts

### DIFF
--- a/coffee-machine-adapters/README.md
+++ b/coffee-machine-adapters/README.md
@@ -17,7 +17,7 @@ The adapters are divided into two main categories: input and output.
 
 *   **`CoffeeMachineH2Repository`**: This is an implementation of the `CoffeeMachineRepository` port that uses an in-memory H2 database to persist the state of the `CoffeeMachine` aggregate.
 *   **`RecipeH2Repository`**: This is an implementation of the `RecipeRepository` port that uses an in-memory H2 database to persist the `Recipe` aggregate.
-*   **`ConsoleDomainEventPublisher`**: This is an implementation of the `DomainEventPublisher` port that simply prints the domain events to the console.
+*   **`ConsoleDomainEventPublisher`**: This is an implementation of the `EventPublisher` port that simply prints the domain events to the console.
 
 ## Technology Stack
 

--- a/coffee-machine-adapters/src/main/kotlin/com/yonatankarp/coffeemachine/adapters/AdaptersConfiguration.kt
+++ b/coffee-machine-adapters/src/main/kotlin/com/yonatankarp/coffeemachine/adapters/AdaptersConfiguration.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.coffeemachine.adapters
 
-import com.yonatankarp.coffeemachine.application.ports.output.DomainEventPublisher
+import com.yonatankarp.coffeemachine.application.ports.output.EventPublisher
 import com.yonatankarp.coffeemachine.application.usecase.BrewCoffeeUseCase
 import com.yonatankarp.coffeemachine.application.usecase.CoffeeMachinePowerUseCase
 import com.yonatankarp.coffeemachine.application.usecase.CoffeeMachineRefillUseCase
@@ -17,7 +17,7 @@ class AdaptersConfiguration {
     fun brewCoffeeUseCase(
         coffeeMachineRepository: CoffeeMachineRepository,
         recipeRepository: RecipeRepository,
-        publisher: DomainEventPublisher,
+        publisher: EventPublisher,
     ) = BrewCoffeeUseCase(coffeeMachineRepository, recipeRepository, publisher)
 
     @Bean

--- a/coffee-machine-adapters/src/main/kotlin/com/yonatankarp/coffeemachine/adapters/output/cli/ConsoleDomainEventPublisher.kt
+++ b/coffee-machine-adapters/src/main/kotlin/com/yonatankarp/coffeemachine/adapters/output/cli/ConsoleDomainEventPublisher.kt
@@ -1,12 +1,12 @@
 package com.yonatankarp.coffeemachine.adapters.output.cli
 
-import com.yonatankarp.coffeemachine.application.ports.output.DomainEventPublisher
+import com.yonatankarp.coffeemachine.application.ports.output.EventPublisher
 import com.yonatankarp.coffeemachine.domain.machine.event.DomainEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 
 @Component
-class ConsoleDomainEventPublisher : DomainEventPublisher {
+class ConsoleDomainEventPublisher : EventPublisher {
     private val logger = KotlinLogging.logger {}
 
     override fun publish(event: DomainEvent) {

--- a/coffee-machine-adapters/src/test/kotlin/com/yonatankarp/coffeemachine/adapters/input/cli/CliRunnerTest.kt
+++ b/coffee-machine-adapters/src/test/kotlin/com/yonatankarp/coffeemachine/adapters/input/cli/CliRunnerTest.kt
@@ -1,11 +1,11 @@
 package com.yonatankarp.coffeemachine.adapters.input.cli
 
 import ch.qos.logback.classic.Level
-import com.yonatankarp.coffeemachine.application.ports.input.BrewCoffeePort
-import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachinePowerPort
-import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachineRefillPort
-import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachineStatusPort
-import com.yonatankarp.coffeemachine.application.ports.input.FindAllRecipesPort
+import com.yonatankarp.coffeemachine.application.ports.input.BrewCoffee
+import com.yonatankarp.coffeemachine.application.ports.input.BrowseRecipes
+import com.yonatankarp.coffeemachine.application.ports.input.GetMachineStatus
+import com.yonatankarp.coffeemachine.application.ports.input.ManageMachine
+import com.yonatankarp.coffeemachine.application.ports.input.RefillMachine
 import com.yonatankarp.coffeemachine.domain.machine.RefillType
 import com.yonatankarp.coffeemachine.domain.machine.event.DomainEvent
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatusFixture
@@ -22,11 +22,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CliRunnerTest {
-    private val brew = mockk<BrewCoffeePort>()
-    private val power = mockk<CoffeeMachinePowerPort>()
-    private val refill = mockk<CoffeeMachineRefillPort>()
-    private val status = mockk<CoffeeMachineStatusPort>()
-    private val listRecipes = mockk<FindAllRecipesPort>()
+    private val brewCoffee = mockk<BrewCoffee>()
+    private val manageMachine = mockk<ManageMachine>()
+    private val refillMachine = mockk<RefillMachine>()
+    private val getMachineStatus = mockk<GetMachineStatus>()
+    private val browseRecipes = mockk<BrowseRecipes>()
 
     @BeforeEach
     fun setup() {
@@ -36,13 +36,13 @@ class CliRunnerTest {
     @Test
     fun `prints banner, help and bye for help then quit`() {
         // Given
-        every { power(any()) } returns MachineStatusFixture.poweredOn
-        every { status.invoke() } returns MachineStatusFixture.poweredOn
-        every { refill(any()) } returns MachineStatusFixture.poweredOn
-        every { listRecipes.invoke() } returns emptyList()
-        every { brew.invoke(any()) } returns emptyList()
+        every { manageMachine(any()) } returns MachineStatusFixture.poweredOn
+        every { getMachineStatus.invoke() } returns MachineStatusFixture.poweredOn
+        every { refillMachine(any()) } returns MachineStatusFixture.poweredOn
+        every { browseRecipes.invoke() } returns emptyList()
+        every { brewCoffee.invoke(any()) } returns emptyList()
 
-        val runner = CliRunner(brew, power, refill, status, listRecipes)
+        val runner = CliRunner(brewCoffee, manageMachine, refillMachine, getMachineStatus, browseRecipes)
 
         WithSystemIn("help", "quit").use {
             LogCapture(CliRunner::class.java, Level.INFO).use { logs ->
@@ -55,7 +55,7 @@ class CliRunnerTest {
                     Command.help,
                     "Bye 👋",
                 )
-                verify(exactly = 0) { brew(any()) }
+                verify(exactly = 0) { brewCoffee(any()) }
             }
         }
     }
@@ -63,13 +63,13 @@ class CliRunnerTest {
     @Test
     fun `unknown command logs hint and continues`() {
         // Given
-        every { power(any()) } returns MachineStatusFixture.poweredOn
-        every { status.invoke() } returns MachineStatusFixture.poweredOn
-        every { refill(any()) } returns MachineStatusFixture.poweredOn
-        every { listRecipes.invoke() } returns emptyList()
-        every { brew.invoke(any()) } returns emptyList()
+        every { manageMachine(any()) } returns MachineStatusFixture.poweredOn
+        every { getMachineStatus.invoke() } returns MachineStatusFixture.poweredOn
+        every { refillMachine(any()) } returns MachineStatusFixture.poweredOn
+        every { browseRecipes.invoke() } returns emptyList()
+        every { brewCoffee.invoke(any()) } returns emptyList()
 
-        val runner = CliRunner(brew, power, refill, status, listRecipes)
+        val runner = CliRunner(brewCoffee, manageMachine, refillMachine, getMachineStatus, browseRecipes)
 
         WithSystemIn("does-not-exist", "quit").use {
             LogCapture(CliRunner::class.java).use { logs ->
@@ -83,7 +83,7 @@ class CliRunnerTest {
                     "Unrecognized command. Type 'help'.",
                     "Bye 👋",
                 )
-                verify(exactly = 0) { brew(any()) }
+                verify(exactly = 0) { brewCoffee(any()) }
             }
         }
     }
@@ -91,15 +91,15 @@ class CliRunnerTest {
     @Test
     fun `power status refill recipes brew espresso invoke corresponding ports`() {
         // Given
-        every { power(true) } returns MachineStatusFixture.poweredOn
-        every { status.invoke() } returns MachineStatusFixture.poweredOn
-        every { refill(RefillType.WATER) } returns MachineStatusFixture.poweredOn
-        every { refill(RefillType.BEANS) } returns MachineStatusFixture.poweredOn
-        every { refill(RefillType.WASTE) } returns MachineStatusFixture.poweredOn
-        every { listRecipes.invoke() } returns emptyList()
-        every { brew(Recipe.Name.ESPRESSO) } returns listOf(DomainEvent.BrewCompleted(Recipe.Name.ESPRESSO))
+        every { manageMachine(true) } returns MachineStatusFixture.poweredOn
+        every { getMachineStatus.invoke() } returns MachineStatusFixture.poweredOn
+        every { refillMachine(RefillType.WATER) } returns MachineStatusFixture.poweredOn
+        every { refillMachine(RefillType.BEANS) } returns MachineStatusFixture.poweredOn
+        every { refillMachine(RefillType.WASTE) } returns MachineStatusFixture.poweredOn
+        every { browseRecipes.invoke() } returns emptyList()
+        every { brewCoffee(Recipe.Name.ESPRESSO) } returns listOf(DomainEvent.BrewCompleted(Recipe.Name.ESPRESSO))
 
-        val runner = CliRunner(brew, power, refill, status, listRecipes)
+        val runner = CliRunner(brewCoffee, manageMachine, refillMachine, getMachineStatus, browseRecipes)
 
         WithSystemIn(
             "power on",
@@ -121,13 +121,13 @@ class CliRunnerTest {
                     "Bye 👋",
                 )
 
-                verify(exactly = 1) { power(true) }
-                verify(exactly = 1) { status.invoke() }
-                verify(exactly = 1) { listRecipes.invoke() }
-                verify(exactly = 1) { refill(RefillType.WATER) }
-                verify(exactly = 1) { refill(RefillType.BEANS) }
-                verify(exactly = 1) { refill(RefillType.WASTE) }
-                verify(exactly = 1) { brew(Recipe.Name.ESPRESSO) }
+                verify(exactly = 1) { manageMachine(true) }
+                verify(exactly = 1) { getMachineStatus.invoke() }
+                verify(exactly = 1) { browseRecipes.invoke() }
+                verify(exactly = 1) { refillMachine(RefillType.WATER) }
+                verify(exactly = 1) { refillMachine(RefillType.BEANS) }
+                verify(exactly = 1) { refillMachine(RefillType.WASTE) }
+                verify(exactly = 1) { brewCoffee(Recipe.Name.ESPRESSO) }
             }
         }
     }
@@ -135,13 +135,13 @@ class CliRunnerTest {
     @Test
     fun `brew unknown recipe prints friendly message and does not call brew`() {
         // Given
-        every { power(any()) } returns MachineStatusFixture.poweredOn
-        every { status.invoke() } returns MachineStatusFixture.poweredOn
-        every { refill(any()) } returns MachineStatusFixture.poweredOn
-        every { listRecipes.invoke() } returns emptyList()
-        every { brew.invoke(any()) } returns emptyList()
+        every { manageMachine(any()) } returns MachineStatusFixture.poweredOn
+        every { getMachineStatus.invoke() } returns MachineStatusFixture.poweredOn
+        every { refillMachine(any()) } returns MachineStatusFixture.poweredOn
+        every { browseRecipes.invoke() } returns emptyList()
+        every { brewCoffee.invoke(any()) } returns emptyList()
 
-        val runner = CliRunner(brew, power, refill, status, listRecipes)
+        val runner = CliRunner(brewCoffee, manageMachine, refillMachine, getMachineStatus, browseRecipes)
 
         WithSystemIn("brew not_a_recipe", "quit").use {
             LogCapture(CliRunner::class.java).use { logs ->
@@ -149,7 +149,7 @@ class CliRunnerTest {
                 runner.run()
 
                 logs.messages shouldContain "Unknown recipe 'NOT_A_RECIPE'. Try 'recipes'."
-                verify(exactly = 0) { brew(any()) }
+                verify(exactly = 0) { brewCoffee(any()) }
             }
         }
     }

--- a/coffee-machine-application/README.md
+++ b/coffee-machine-application/README.md
@@ -8,11 +8,11 @@ The application layer is composed of a set of use cases, each of which represent
 
 ### Use Cases
 
-*   **`BrewCoffeeUseCase`**: Brews a coffee recipe. It loads the `CoffeeMachine` and `Recipe` aggregates, invokes the `brew` method on the `CoffeeMachine`, and saves the updated machine state.
-*   **`CoffeeMachinePowerUseCase`**: Turns the coffee machine on or off.
-*   **`CoffeeMachineRefillUseCase`**: Refills the water tank, bean hopper, or empties the waste bin.
-*   **`CoffeeMachineStatusUseCase`**: Retrieves the current status of the coffee machine.
-*   **`FindAllRecipesUseCase`**: Retrieves a list of all available coffee recipes.
+*   **`BrewCoffee`**: Brews a coffee recipe. It loads the `CoffeeMachine` and `Recipe` aggregates, invokes the `brew` method on the `CoffeeMachine`, and saves the updated machine state.
+*   **`ManageMachine`**: Turns the coffee machine on or off.
+*   **`RefillMachine`**: Refills the water tank, bean hopper, or empties the waste bin.
+*   **`GetMachineStatus`**: Retrieves the current status of the coffee machine.
+*   **`BrowseRecipes`**: Retrieves a list of all available coffee recipes.
 
 ## Request Lifecycle Sequence Diagram
 
@@ -23,7 +23,7 @@ sequenceDiagram
     autonumber
     participant User
     participant InputAdapter as CLI Adapter
-    participant UseCase as BrewCoffeeUseCase
+    participant UseCase as BrewCoffee
     participant CoffeeMachineRepo as CoffeeMachineRepository
     participant RecipeRepo as RecipeRepository
     participant Domain as CoffeeMachine Aggregate
@@ -44,3 +44,4 @@ sequenceDiagram
     UseCase->>CoffeeMachineRepo: save(updatedMachine)
     CoffeeMachineRepo->>DB: UPDATE coffee_machine
     InputAdapter-->>User: "Brewing ESPRESSO... ☕"
+```

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/BrewCoffee.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/BrewCoffee.kt
@@ -3,6 +3,6 @@ package com.yonatankarp.coffeemachine.application.ports.input
 import com.yonatankarp.coffeemachine.domain.machine.event.DomainEvent
 import com.yonatankarp.coffeemachine.domain.recipe.Recipe
 
-fun interface BrewCoffeePort {
+fun interface BrewCoffee {
     operator fun invoke(recipeName: Recipe.Name): List<DomainEvent>
 }

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/BrowseRecipes.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/BrowseRecipes.kt
@@ -2,6 +2,6 @@ package com.yonatankarp.coffeemachine.application.ports.input
 
 import com.yonatankarp.coffeemachine.domain.recipe.Recipe
 
-fun interface FindAllRecipesPort {
+fun interface BrowseRecipes {
     operator fun invoke(): List<Recipe>
 }

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/GetMachineStatus.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/GetMachineStatus.kt
@@ -2,6 +2,6 @@ package com.yonatankarp.coffeemachine.application.ports.input
 
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatus
 
-fun interface CoffeeMachinePowerPort {
-    operator fun invoke(on: Boolean): MachineStatus
+fun interface GetMachineStatus {
+    operator fun invoke(): MachineStatus
 }

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/ManageMachine.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/ManageMachine.kt
@@ -2,6 +2,6 @@ package com.yonatankarp.coffeemachine.application.ports.input
 
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatus
 
-fun interface CoffeeMachineStatusPort {
-    operator fun invoke(): MachineStatus
+fun interface ManageMachine {
+    operator fun invoke(on: Boolean): MachineStatus
 }

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/RefillMachine.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/input/RefillMachine.kt
@@ -3,6 +3,6 @@ package com.yonatankarp.coffeemachine.application.ports.input
 import com.yonatankarp.coffeemachine.domain.machine.RefillType
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatus
 
-fun interface CoffeeMachineRefillPort {
+fun interface RefillMachine {
     operator fun invoke(type: RefillType): MachineStatus
 }

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/output/EventPublisher.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/ports/output/EventPublisher.kt
@@ -2,7 +2,7 @@ package com.yonatankarp.coffeemachine.application.ports.output
 
 import com.yonatankarp.coffeemachine.domain.machine.event.DomainEvent
 
-interface DomainEventPublisher {
+interface EventPublisher {
     fun publish(event: DomainEvent)
 
     fun publishAll(events: List<DomainEvent>) = events.forEach(::publish)

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/BrewCoffeeUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/BrewCoffeeUseCase.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
-import com.yonatankarp.coffeemachine.application.ports.input.BrewCoffeePort
-import com.yonatankarp.coffeemachine.application.ports.output.DomainEventPublisher
+import com.yonatankarp.coffeemachine.application.ports.input.BrewCoffee
+import com.yonatankarp.coffeemachine.application.ports.output.EventPublisher
 import com.yonatankarp.coffeemachine.domain.machine.event.DomainEvent
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 import com.yonatankarp.coffeemachine.domain.recipe.Recipe
@@ -10,8 +10,8 @@ import com.yonatankarp.coffeemachine.domain.recipe.port.RecipeRepository
 class BrewCoffeeUseCase(
     private val coffeeMachineRepository: CoffeeMachineRepository,
     private val recipeRepository: RecipeRepository,
-    private val publisher: DomainEventPublisher,
-) : BrewCoffeePort {
+    private val publisher: EventPublisher,
+) : BrewCoffee {
     override fun invoke(recipeName: Recipe.Name): List<DomainEvent> {
         val recipe = recipeRepository.findByName(recipeName) ?: return emptyList()
 

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachinePowerUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachinePowerUseCase.kt
@@ -1,12 +1,12 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
-import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachinePowerPort
+import com.yonatankarp.coffeemachine.application.ports.input.ManageMachine
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatus
 
 class CoffeeMachinePowerUseCase(
     private val coffeeMachineRepository: CoffeeMachineRepository,
-) : CoffeeMachinePowerPort {
+) : ManageMachine {
     override operator fun invoke(on: Boolean): MachineStatus {
         val machine = coffeeMachineRepository.load()
         val updated = if (on) machine.powerOn() else machine.powerOff()

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineRefillUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineRefillUseCase.kt
@@ -1,13 +1,13 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
-import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachineRefillPort
+import com.yonatankarp.coffeemachine.application.ports.input.RefillMachine
 import com.yonatankarp.coffeemachine.domain.machine.RefillType
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatus
 
 class CoffeeMachineRefillUseCase(
     private val coffeeMachineRepository: CoffeeMachineRepository,
-) : CoffeeMachineRefillPort {
+) : RefillMachine {
     override fun invoke(type: RefillType): MachineStatus {
         val machine = coffeeMachineRepository.load()
         val updated = machine.refill(type)

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineStatusUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/CoffeeMachineStatusUseCase.kt
@@ -1,11 +1,11 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
-import com.yonatankarp.coffeemachine.application.ports.input.CoffeeMachineStatusPort
+import com.yonatankarp.coffeemachine.application.ports.input.GetMachineStatus
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 import com.yonatankarp.coffeemachine.domain.machine.status.MachineStatus
 
 class CoffeeMachineStatusUseCase(
     private val coffeeMachineRepository: CoffeeMachineRepository,
-) : CoffeeMachineStatusPort {
+) : GetMachineStatus {
     override fun invoke() = MachineStatus.from(coffeeMachineRepository.load())
 }

--- a/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/FindAllRecipesUseCase.kt
+++ b/coffee-machine-application/src/main/kotlin/com/yonatankarp/coffeemachine/application/usecase/FindAllRecipesUseCase.kt
@@ -1,11 +1,11 @@
 package com.yonatankarp.coffeemachine.application.usecase
 
-import com.yonatankarp.coffeemachine.application.ports.input.FindAllRecipesPort
+import com.yonatankarp.coffeemachine.application.ports.input.BrowseRecipes
 import com.yonatankarp.coffeemachine.domain.recipe.Recipe
 import com.yonatankarp.coffeemachine.domain.recipe.port.RecipeRepository
 
 class FindAllRecipesUseCase(
     private val recipeRepository: RecipeRepository,
-) : FindAllRecipesPort {
+) : BrowseRecipes {
     override fun invoke(): List<Recipe> = recipeRepository.list()
 }

--- a/coffee-machine-application/src/test/kotlin/com/yonatankarp/coffeemachine/application/fakes/CollectingPublisher.kt
+++ b/coffee-machine-application/src/test/kotlin/com/yonatankarp/coffeemachine/application/fakes/CollectingPublisher.kt
@@ -1,9 +1,9 @@
 package com.yonatankarp.coffeemachine.application.fakes
 
-import com.yonatankarp.coffeemachine.application.ports.output.DomainEventPublisher
+import com.yonatankarp.coffeemachine.application.ports.output.EventPublisher
 import com.yonatankarp.coffeemachine.domain.machine.event.DomainEvent
 
-class CollectingPublisher : DomainEventPublisher {
+class CollectingPublisher : EventPublisher {
     val published = mutableListOf<DomainEvent>()
 
     override fun publish(event: DomainEvent) {


### PR DESCRIPTION


# Purpose

This commit changes the names of the ports to more domain concepts rather than technical concepts to ensure that the business behind them is clear.

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized naming across application ports for clarity and consistency.
  - Unified event publishing interface naming.
  - Updated CLI wiring to align with new names; behavior unchanged.

- Tests
  - Adjusted mocks and verifications to the updated APIs.
  - Added setup step to clear mocks between tests.

- Chores
  - Updated internal dependencies to use the new interfaces.
  - No user-facing changes; existing commands and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->