### PR TITLE
Use domain exceptions

### DIFF
--- a/coffee-machine-adapters/src/main/kotlin/com/yonatankarp/coffeemachine/adapters/output/db/h2/CoffeeMachineH2Repository.kt
+++ b/coffee-machine-adapters/src/main/kotlin/com/yonatankarp/coffeemachine/adapters/output/db/h2/CoffeeMachineH2Repository.kt
@@ -3,6 +3,7 @@ package com.yonatankarp.coffeemachine.adapters.output.db.h2
 import com.yonatankarp.coffeemachine.adapters.output.db.h2.mapper.CoffeeMachineMapper.toDomain
 import com.yonatankarp.coffeemachine.adapters.output.db.h2.mapper.CoffeeMachineMapper.toEntity
 import com.yonatankarp.coffeemachine.domain.machine.CoffeeMachine
+import com.yonatankarp.coffeemachine.domain.machine.exception.CoffeeMachineException
 import com.yonatankarp.coffeemachine.domain.machine.port.CoffeeMachineRepository
 import org.springframework.stereotype.Repository
 
@@ -12,7 +13,7 @@ class CoffeeMachineH2Repository(
 ) : CoffeeMachineRepository {
     override fun load(): CoffeeMachine =
         jpaRepository.findAll().firstOrNull()?.toDomain()
-            ?: throw IllegalStateException("No coffee machine") // TODO: handle with domain error
+            ?: throw CoffeeMachineException.NoCoffeeMachineFound()
 
     override fun save(machine: CoffeeMachine): CoffeeMachine = jpaRepository.save(machine.toEntity()).toDomain()
 }

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/exception/CoffeeMachineException.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/machine/exception/CoffeeMachineException.kt
@@ -1,0 +1,7 @@
+package com.yonatankarp.coffeemachine.domain.machine.exception
+
+sealed class CoffeeMachineException(
+    message: String,
+) : Exception(message) {
+    class NoCoffeeMachineFound : CoffeeMachineException("No coffee machine found")
+}

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/recipe/Recipe.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/recipe/Recipe.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.coffeemachine.domain.recipe
 
+import com.yonatankarp.coffeemachine.domain.recipe.exceptions.RecipeException
 import com.yonatankarp.coffeemachine.domain.shared.unit.Celsius
 import com.yonatankarp.coffeemachine.domain.shared.unit.Grams
 import com.yonatankarp.coffeemachine.domain.shared.unit.Milliliters
@@ -44,9 +45,7 @@ data class Recipe(
                 return entries.firstOrNull { enum ->
                     enum.name == normalized.replace(' ', '_') ||
                         enum.displayName.uppercase() == normalized
-                } ?: throw IllegalArgumentException(
-                    "Unknown recipe: $value. Expected one of: ${entries.joinToString { it.displayName }}",
-                )
+                } ?: throw RecipeException.UnknownRecipeName(value)
             }
         }
     }

--- a/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/recipe/exceptions/RecipeException.kt
+++ b/coffee-machine-domain/src/main/kotlin/com/yonatankarp/coffeemachine/domain/recipe/exceptions/RecipeException.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.coffeemachine.domain.recipe.exceptions
+
+import com.yonatankarp.coffeemachine.domain.recipe.Recipe.Name.entries
+
+sealed class RecipeException(
+    message: String,
+) : Exception(message) {
+    class UnknownRecipeName(
+        name: String,
+    ) : RecipeException("Unknown recipe: $name. Expected one of: ${entries.joinToString { it.displayName }}")
+}

--- a/coffee-machine-domain/src/test/kotlin/com/yonatankarp/coffeemachine/domain/recipe/RecipeTest.kt
+++ b/coffee-machine-domain/src/test/kotlin/com/yonatankarp/coffeemachine/domain/recipe/RecipeTest.kt
@@ -1,0 +1,106 @@
+package com.yonatankarp.coffeemachine.domain.recipe
+
+import com.yonatankarp.coffeemachine.domain.recipe.exceptions.RecipeException
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class RecipeTest {
+    @Nested
+    inner class Name {
+        @ParameterizedTest(name = "from(\"{0}\") -> {1}")
+        @CsvSource(
+            "ESPRESSO, ESPRESSO",
+            " espresso , ESPRESSO",
+            "eSpReSsO, ESPRESSO",
+            "Espresso, ESPRESSO",
+            "  Double   Espresso , DOUBLE_ESPRESSO",
+            "double-espresso, DOUBLE_ESPRESSO",
+            "DOUBLE_ESPRESSO, DOUBLE_ESPRESSO",
+            "long  black, LONG_BLACK",
+            "LONG-BLACK, LONG_BLACK",
+            "LONG_BLACK, LONG_BLACK",
+            "flat_white, FLAT_WHITE",
+            "flat-  white, FLAT_WHITE",
+            "  flat   white  , FLAT_WHITE",
+            "Americano, AMERICANO",
+            "cappuccino, CAPPUCCINO",
+            "cortado, CORTADO",
+            "ristretto, RISTRETTO",
+            "lungo, LUNGO",
+            "latte, LATTE",
+        )
+        fun `parses common variants of name or displayName`(
+            input: String,
+            expectedEnumName: String,
+        ) {
+            // Given
+            // When
+            val actual = Recipe.Name.from(input)
+
+            // Then
+            actual.name shouldBe expectedEnumName
+        }
+    }
+
+    @ParameterizedTest(name = "DisplayName mapping for {0}")
+    @MethodSource("allDisplayNameCases")
+    fun `accepts each enum displayName as input`(
+        displayName: String,
+        expected: Recipe.Name,
+    ) {
+        // Given
+        // When
+        val actual = Recipe.Name.from(displayName)
+
+        // Then
+        actual shouldBe expected
+    }
+
+    @Test
+    fun `normalization rules are applied consistently`() {
+        // Given
+        val inputs =
+            listOf(
+                "  DOUBLE   ESPRESSO ",
+                "double-espresso",
+                "DOUBLE_ESPRESSO",
+                "Double   Espresso",
+                "dOuBlE   eSpReSsO",
+            )
+
+        // When
+        val results = inputs.map { Recipe.Name.from(it) }
+
+        // Then
+        results.distinct() shouldContainExactlyInAnyOrder listOf(Recipe.Name.DOUBLE_ESPRESSO)
+    }
+
+    @Test
+    fun `throws with helpful message on unknown recipe`() {
+        // Given
+        val bad = "macchiatissimo"
+
+        // When / Then
+        shouldThrowWithMessage<RecipeException.UnknownRecipeName>(
+            "Unknown recipe: macchiatissimo. Expected one of: Espresso, Ristretto, Lungo, Americano, Long Black, Latte, Cappuccino, Flat White, Double Espresso, Cortado",
+        ) {
+            Recipe.Name.from(bad)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun allDisplayNameCases(): Stream<Arguments> =
+            Recipe.Name.entries
+                .stream()
+                .map { Arguments.of(it.displayName, it) }
+    }
+}


### PR DESCRIPTION


# Purpose

This commit changes the usage of generic exceptions with domain exception that are used inside the application to give better visibility on what is wrong with business logic when error accord

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced generic errors with clear, domain-specific messages when no coffee machine is found.
  * Improved feedback for unknown recipe names with a user-friendly message listing valid options.

* **Tests**
  * Added comprehensive tests for recipe name parsing, normalization, and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->